### PR TITLE
Wrong gwt module location in jar

### DIFF
--- a/gwt-event-dom/pom.xml
+++ b/gwt-event-dom/pom.xml
@@ -68,7 +68,7 @@
         <version>${maven.gwt.plugin}</version>
         <extensions>true</extensions>
         <configuration>
-          <moduleName>org.gwtproject.event.EventDOM</moduleName>
+          <moduleName>org.gwtproject.event.dom.DomEvent</moduleName>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
    Version using : 1.0.0-RC1
    Module configuration: <inherits name="org.gwtproject.event.EventDOM" />

   The following setup leads to:

      [ERROR] Line 80: No source code is available for type org.gwtproject.event.dom.client.DomEvent.Type<H>; did you forget to inherit a required module?
      [ERROR] Line 218: No source code is available for type org.gwtproject.event.dom.client.DomEvent<H>; did you forget to inherit a required module?

The reason of this error is wrong gwt-lib configuration: 

```
	 <configuration>
          <moduleName>org.gwtproject.event.EventDOM</moduleName>
        </configuration>
```
	but :
```
	<source path="client" />
```
	which is located under org.gwtproject.event.dom, not org.gwtproject.event. As a result,  gwt isn't able to locate the  sources.

	PS: in gwt2, full module name is com.google.gwt.event.dom.DomEvent, so i propose to switch to org.gwtproject.event.dom.DomEvent