### PR TITLE
Reset source after event handling

### DIFF
--- a/gwt-event-dom/src/main/java/org/gwtproject/event/dom/client/DomEvent.java
+++ b/gwt-event-dom/src/main/java/org/gwtproject/event/dom/client/DomEvent.java
@@ -66,11 +66,13 @@ public abstract class DomEvent<H extends EventHandler> extends Event<H> implemen
           // loop.
           NativeEvent currentNative = type.flyweight.nativeEvent;
           Element currentRelativeElem = type.flyweight.relativeElem;
+          Object currentSource = type.flyweight.getSource();
           type.flyweight.setNativeEvent(nativeEvent);
           type.flyweight.setRelativeElement(relativeElem);
           handlerSource.fireEvent(type.flyweight);
           type.flyweight.setNativeEvent(currentNative);
           type.flyweight.setRelativeElement(currentRelativeElem);
+          type.flyweight.setSource(currentSource);
         }
       }
     }


### PR DESCRIPTION
The DOM events in GWT 2.10 are subclasses of `GwtEvent` which takes care of resetting source using kill/revive. The new implementation that uses `Event` directly does not do that, which leads to private static flyweight objects keeping a reference to the last handled event source and thus leaking memory.

This PR does not add any tests because parts of `DomEventTest` are commented out, waiting for j2cl-compatible implementation of Widget.